### PR TITLE
Update Navbar with auth info

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 const Navbar: React.FC = () => {
+  const { user, isAuthenticated, logout } = useAuth();
   return (
     <nav className="bg-white shadow-lg">
       <div className="container mx-auto px-4">
@@ -20,18 +22,29 @@ const Navbar: React.FC = () => {
           </div>
 
           <div className="flex items-center space-x-4">
-            <Link
-              to="/login"
-              className="text-gray-700 hover:text-primary-600"
-            >
-              Iniciar Sesión
-            </Link>
-            <Link
-              to="/register"
-              className="bg-primary-600 text-white px-4 py-2 rounded-md hover:bg-primary-700"
-            >
-              Registrarse
-            </Link>
+            {!isAuthenticated ? (
+              <>
+                <Link to="/login" className="text-gray-700 hover:text-primary-600">
+                  Iniciar Sesión
+                </Link>
+                <Link
+                  to="/register"
+                  className="bg-primary-600 text-white px-4 py-2 rounded-md hover:bg-primary-700"
+                >
+                  Registrarse
+                </Link>
+              </>
+            ) : (
+              <>
+                <span className="text-gray-700">{user?.name}</span>
+                <button
+                  onClick={logout}
+                  className="bg-primary-600 text-white px-4 py-2 rounded-md hover:bg-primary-700"
+                >
+                  Cerrar sesión
+                </button>
+              </>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- use `useAuth` to access auth info
- show login/register for guests
- show logged in user name and logout button when authenticated

## Testing
- `npm test --silent --if-present` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b0053d108321a9df6a231a26940e