### PR TITLE
Use auth context login

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import axios from '../services/api';
+import { useAuth } from '../context/AuthContext';
 
 const Login: React.FC = () => {
   const navigate = useNavigate();
+  const { login } = useAuth();
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -27,16 +28,11 @@ const Login: React.FC = () => {
     setError('');
 
     try {
-      const response = await axios.post('/auth/login', formData);
-      
-      // Guardar el token en localStorage
-      localStorage.setItem('token', response.data.data.token);
-      
-      // Redirigir al dashboard
+      await login(formData);
       navigate('/dashboard');
     } catch (error: any) {
       setError(
-        error.response?.data?.message || 
+        error.response?.data?.message ||
         'Error al iniciar sesión. Por favor, intenta de nuevo.'
       );
     } finally {
@@ -131,4 +127,4 @@ const Login: React.FC = () => {
   );
 };
 
-export default Login; 
+export default Login;


### PR DESCRIPTION
## Summary
- refactor login page to use `useAuth` login method

## Testing
- `npx -y tsc -p frontend/tsconfig.json --noEmit` *(fails: cannot find module 'react')*
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844aff583d48321b97c778a01c51024