### PR TITLE
Fix product route order

### DIFF
--- a/backend/routes/product.routes.js
+++ b/backend/routes/product.routes.js
@@ -12,12 +12,12 @@ const { protect, authorize } = require('../middleware/auth.middleware');
 
 // Rutas públicas
 router.get('/', getProducts);
+router.get('/seller/products', protect, getSellerProducts);
 router.get('/:id', getProductById);
 
 // Rutas protegidas
 router.post('/', protect, createProduct);
 router.put('/:id', protect, updateProduct);
 router.delete('/:id', protect, deleteProduct);
-router.get('/seller/products', protect, getSellerProducts);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- fix order of `/seller/products` route so it isn't shadowed by `/:id`

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844adb0cd9083218c6cd775f3fb77df