### PR TITLE
Add backend start script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "keywords": [],
   "author": "",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -49,6 +49,14 @@ yarn start
 
 La aplicación estará disponible en `http://localhost:3000`
 
+## Ejecutar el Backend
+
+Desde la carpeta `backend`, inicia el servidor con:
+
+```bash
+npm start
+```
+
 ## Estructura del Proyecto
 
 ```


### PR DESCRIPTION
## Summary
- enable `npm start` for backend by invoking `node app.js`
- document how to run the backend server in the README

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b01a3f088321ac332d7d5dfc75f3